### PR TITLE
Enhance querystring handling when appending vcc_param

### DIFF
--- a/IFTTT-Dash-Button.ino
+++ b/IFTTT-Dash-Button.ino
@@ -209,7 +209,13 @@ void loop()
     //create the URI for the request
     if (s_vcc)
     {
-      url += "?";
+      if (url.indexOf("?") > 0) {
+        // if the configured url already has a querystring, append an ampersand
+        url += "&";
+      } else {
+        // otherwise start the new querystring
+        url += "?";
+      }
       url += vcc_parm;
       url += "=";
       uint32_t getVcc = ESP.getVcc();


### PR DESCRIPTION
When appending the vcc_param to the url, check whether the configured url already has a "?" and if so append an "&" instead.